### PR TITLE
update Install Package command to dotnet syntax

### DIFF
--- a/docs/v3/extensions/mqttEntityManager.md
+++ b/docs/v3/extensions/mqttEntityManager.md
@@ -25,7 +25,7 @@ To set up the Entity Manager manually you should:
 - Include the JoySoftware.NetDaemon.Extensions.MqttEntityManager NuGet package 
 
 ```ps
-Install-Package JoySoftware.NetDaemon.Extensions.Mqtt
+dotnet add package JoySoftware.NetDaemon.Extensions.Mqtt
 ```
 
 


### PR DESCRIPTION
Small documentation change to go from `Install-Package JoySoftware.NetDaemon.Extensions.Mqtt` to `dotnet add package JoySoftware.NetDaemon.Extensions.Mqtt`

took me too long to remember what the command was and don't want other people to be confused like me :)